### PR TITLE
Better support for circa variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+.idea/*
+*.pyc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .idea/*
 *.pyc
+docs/build/*

--- a/datautil/date.py
+++ b/datautil/date.py
@@ -1,9 +1,12 @@
-'''Date parsing and normalization utilities based on FlexiDate.
+"""
+Date parsing and normalization utilities based on FlexiDate.
 
-To parser dates use parse, e.g.::
+To parse dates use parse(), e.g.::
 
-    parse('1890') -> FlexiDate(year=u'1890')
-    parse('1890?') -> FlexiDate(year=u'1890', qualifier='Uncertainty: 1985?')
+from datautil.date import parse
+
+parse('1890') -> FlexiDate(year=u'1890')
+parse('1890?') -> FlexiDate(year=u'1890', qualifier='Uncertainty: 1985?')
 
 Once you have a FlexiDate you can get access to attributes (strings of course
 ...)::
@@ -12,7 +15,7 @@ Once you have a FlexiDate you can get access to attributes (strings of course
     fd.year # u'1890'
     fd.month # u'01'
 
-And convert to other forms:
+And convert to other forms::
 
     fd.as_float() # 1890
     fd.as_datetime() # datetime(1890,01,01)
@@ -29,8 +32,11 @@ FlexiDate is focused on supporting:
 
 For more information see:
 
-http://www.rufuspollock.org/2009/06/18/flexible-dates-in-python/
-'''
+`Flexible Dates in Python (including BC) <http://rufuspollock.org/2009/06/18/flexible-dates-in-python/>`_
+
+--------------------
+
+"""
 import re
 import datetime
 
@@ -227,12 +233,28 @@ class DateutilDateParser(DateParserBase):
         # BC seems to mess up parser
         date = date.replace('BC', '')
 
-        # deal with circa: 'c.1950' or 'c1950'
-        circa_match = re.match('([^a-zA-Z]*)c\.?\s*(\d+.*)', date)
+        # deal with circa: expressed as [c|ca|cca|circ|circa] with or without an appended period
+        # and with or without a space, followed by a date
+        # 'c.1950' or 'c1950' 'ca. 1980' 'circ 198?' 'cca. 1980'  'c 1029' 'circa 1960' etc.
+        # see http://en.wikipedia.org/wiki/Circa
+        # TODO: dates like 'circa 178?' and 'circa 178-' fail poorly
+        # 'UNPARSED: circa 178?' / u"Note 'circa' : circa 178-"
+
+
+        # note that the match deliberately does not capture the circa text match
+        # this is done to remove circa bit below
+        #circa_match = re.match('([^a-zA-Z]*)c\.?\s*(\d+.*)', date)
+
+        # use non-matching groups (?:) to avoid refactoring the rest of the parsing
+        circa_match = re.match(r'([^a-zA-Z]*)(?:circa|circ\.?|cca\.?|ca\.?|c\.?)(?:\s*?)([\d\?-]+\s?\?*)', date)
+
         if circa_match:
             # remove circa bit
             qualifiers.append("Note 'circa'")
-            date = ''.join(circa_match.groups())
+            #date = ''.join(circa_match.groups())
+            # if an element in circa_match.groups() is None, an exception is thrown
+            # so instead join the match groups from circa_match that are not none
+            date = ''.join(list(el for el in circa_match.groups() if el))
 
         # deal with p1980 (what does this mean? it can appear in
         # field 008 of MARC records
@@ -279,4 +301,4 @@ class DateutilDateParser(DateParserBase):
         else:
             qualifier = ', '.join(qualifiers) + (' : %s' % orig_date)
         return FlexiDate(year, res.month, res.day, qualifier=qualifier)
-    
+

--- a/datautil/tests/test_date.py
+++ b/datautil/tests/test_date.py
@@ -172,17 +172,94 @@ class TestDateParsers(object):
 #        assert fd.as_float() == u'1980', fd.as_float()
 
     def test_parse_with_qualifiers(self):
+
         fd = parse('1985?')
         assert fd.year == u'1985', fd
         assert fd.qualifier == u'Uncertainty : 1985?', fd.qualifier
 
+        #  match '[c|c. |c.] {date}'
         fd = parse('c.1780')
         assert fd.year == u'1780', fd
-        assert fd.qualifier == u"Note 'circa' : c.1780", fd
+        assert fd.qualifier.startswith(u"Note 'circa'"), fd
 
         fd = parse('c. 1780')
         assert fd.year == u'1780', fd
         assert fd.qualifier.startswith(u"Note 'circa'"), fd
+
+        fd = parse('c1780')
+        assert fd.year == '1780', fd
+        assert fd.qualifier == u"Note 'circa' : c1780", fd
+
+        fd = parse('c 1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier.startswith(u"Note 'circa'"), fd
+
+        #  match 'circa {date}' | circa{date}'
+        fd = parse('circa1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier == u"Note 'circa' : circa1780", fd
+
+        fd = parse('circa 1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier.startswith(u"Note 'circa'"), fd
+
+        #  match '[circ|circ. |circ.] {date}'
+        fd = parse('circ1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier == u"Note 'circa' : circ1780", fd
+
+        fd = parse('circ 1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier.startswith(u"Note 'circa'"), fd
+
+        fd = parse('circ.1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier == u"Note 'circa' : circ.1780", fd
+
+        fd = parse('circ. 1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier.startswith(u"Note 'circa'"), fd
+
+        #  match '[cca|cca. |cca.] {date}'
+        fd = parse('cca1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier == u"Note 'circa' : cca1780", fd
+
+        fd = parse('cca 1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier.startswith(u"Note 'circa'"), fd
+
+        fd = parse('cca.1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier == u"Note 'circa' : cca.1780", fd
+
+        fd = parse('cca. 1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier.startswith(u"Note 'circa'"), fd
+
+        #  match '[ca|ca. |ca.] {date}'
+
+        fd = parse('ca. 1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier.startswith(u"Note 'circa'"), fd
+
+        fd = parse('ca. 1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier.startswith(u"Note 'circa'"), fd
+
+        fd = parse('ca.1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier.startswith(u"Note 'circa'"), fd
+
+        fd = parse('ca.1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier.startswith(u"Note 'circa'"), fd
+
+        fd = parse('ca.1780')
+        assert fd.year == u'1780', fd
+        assert fd.qualifier.startswith(u"Note 'circa'"), fd
+
+
 
     def test_ambiguous(self):
         # TODO: have to be careful here ...
@@ -204,4 +281,3 @@ class TestDateParsers(object):
         in1 = "p1980"
         fd = parse(in1)
         assert str(fd) == "1980", fd
-        


### PR DESCRIPTION
I was checking out datautil as part of a larger project I'm working on and specifically was running into a lot of parse failures on dates which contained a circa variation (in my case they were either 'ca' or 'ca.') ... I ended up researching it a litte bit and trying to cover as many of the normative variations as I could, because why not be thorough?

I ended up deciding that [c , ca, cca, circ, circa] with or without spaces & and periods was good (although I now wonder if I should have included 'cir' which may also be used in some places)

At any rate, the main change is the circa_match regex which was expanded to 

``` python
r'''([^a-zA-Z]*)
(?:circa
  |circ\.?
  |cca\.?
  |ca\.?
  |c\.?)
(?:\s*?)
([\d\?-]+\s?\?*)'''
```

graph of above:

![circa_regex](https://cloud.githubusercontent.com/assets/320464/6879779/d4b76dc0-d4df-11e4-8136-c1559c221f30.png)

from: 

``` python
r'''
([^a-zA-Z]*)
c\.?\s*
(\d+.*)
'''
```

graph of above

![circa_regex_old](https://cloud.githubusercontent.com/assets/320464/6879760/e14b2ae6-d4de-11e4-9e37-3677f8d706d5.png)
